### PR TITLE
Feature/#1 auth api (#1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@nestjs/core": "^9.0.0",
     "@nestjs/jwt": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",
+    "@nestjs/swagger": "^6.1.3",
     "argon2": "^0.30.2",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ specifiers:
   '@nestjs/jwt': ^9.0.0
   '@nestjs/platform-express': ^9.0.0
   '@nestjs/schematics': ^9.0.0
+  '@nestjs/swagger': ^6.1.3
   '@nestjs/testing': ^9.0.0
   '@types/express': ^4.17.13
   '@types/jest': 28.1.8
@@ -36,6 +37,7 @@ dependencies:
   '@nestjs/core': 9.2.0_jfowmhmgk7kwjudosrpv7e7liy
   '@nestjs/jwt': 9.0.0_@nestjs+common@9.2.0
   '@nestjs/platform-express': 9.2.0_pf2fb646rsvo5szivgkaevcpvi
+  '@nestjs/swagger': 6.1.3_v5qdouhazba6t4koo63x35nolu
   argon2: 0.30.2
   reflect-metadata: 0.1.13
   rimraf: 3.0.2
@@ -949,6 +951,23 @@ packages:
       jsonwebtoken: 8.5.1
     dev: false
 
+  /@nestjs/mapped-types/1.2.0_co7ndddg4j2v72erqtf56w33ee:
+    resolution: {integrity: sha512-NTFwPZkQWsArQH8QSyFWGZvJ08gR+R4TofglqZoihn/vU+ktHEJjMqsIsADwb7XD97DhiD+TVv5ac+jG33BHrg==}
+    peerDependencies:
+      '@nestjs/common': ^7.0.8 || ^8.0.0 || ^9.0.0
+      class-transformer: ^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0
+      class-validator: ^0.11.1 || ^0.12.0 || ^0.13.0
+      reflect-metadata: ^0.1.12
+    peerDependenciesMeta:
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
+    dependencies:
+      '@nestjs/common': 9.2.0_yzt46al3aifnexifjjdb4dxxja
+      reflect-metadata: 0.1.13
+    dev: false
+
   /@nestjs/platform-express/9.2.0_pf2fb646rsvo5szivgkaevcpvi:
     resolution: {integrity: sha512-J1+nnzjC9ATSb0jSHBqAE6D4o+PIbGPItEfYTOZ0rkE5bvqnRfgO4q94SXhfri+5PaNx2vM8tOZsKaD0QmQRGQ==}
     peerDependencies:
@@ -994,6 +1013,30 @@ packages:
     transitivePeerDependencies:
       - chokidar
     dev: true
+
+  /@nestjs/swagger/6.1.3_v5qdouhazba6t4koo63x35nolu:
+    resolution: {integrity: sha512-H9C/yRgLFb5QrAt6iGrYmIX9X7Q0zXkgZaTNUATljUBra+RCWrEUbLHBcGjTAOtcIyGV/vmyCLv68YSVcZoE0Q==}
+    peerDependencies:
+      '@fastify/static': ^6.0.0
+      '@nestjs/common': ^9.0.0
+      '@nestjs/core': ^9.0.0
+      reflect-metadata: ^0.1.12
+    peerDependenciesMeta:
+      '@fastify/static':
+        optional: true
+    dependencies:
+      '@nestjs/common': 9.2.0_yzt46al3aifnexifjjdb4dxxja
+      '@nestjs/core': 9.2.0_jfowmhmgk7kwjudosrpv7e7liy
+      '@nestjs/mapped-types': 1.2.0_co7ndddg4j2v72erqtf56w33ee
+      js-yaml: 4.1.0
+      lodash: 4.17.21
+      path-to-regexp: 3.2.0
+      reflect-metadata: 0.1.13
+      swagger-ui-dist: 4.15.1
+    transitivePeerDependencies:
+      - class-transformer
+      - class-validator
+    dev: false
 
   /@nestjs/testing/9.2.0_3jiwpo56qab566j5kwfezyelg4:
     resolution: {integrity: sha512-Lj6UXmBJKcXB16bZzu0IG7GpH7hl5Cn71OcPSrVVuPrFd5kDYqFbodfE9OkAKaHjEhOvZ2ynoo/i6cyfX4yOvQ==}
@@ -1671,7 +1714,6 @@ packages:
 
   /argparse/2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
-    dev: true
 
   /array-flatten/1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
@@ -3565,7 +3607,6 @@ packages:
     hasBin: true
     dependencies:
       argparse: 2.0.1
-    dev: true
 
   /jsesc/2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
@@ -3721,7 +3762,6 @@ packages:
 
   /lodash/4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-    dev: true
 
   /log-symbols/4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -4640,6 +4680,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
     dev: true
+
+  /swagger-ui-dist/4.15.1:
+    resolution: {integrity: sha512-DlZARu6ckUFqDe0j5IPayO4k0gQvYQw9Un02MhxAgaMtVnTH2vmyyDe+yKeV0r1LiiPx3JbasdS/5Yyb/AV3iw==}
+    dev: false
 
   /symbol-observable/4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { AuthModule } from './auth/auth.module';
 
 @Module({
+  imports: [AuthModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthController } from './auth.controller';
+
+describe('AuthController', () => {
+  let controller: AuthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+    }).compile();
+
+    controller = module.get<AuthController>(AuthController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,50 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { ApiAuthDocument } from 'src/common';
+import { AuthService } from './auth.service';
+import { API_DOC_TYPE } from './constant';
+import { DocumentHelper } from './decorator';
+import {
+  AccessTokenResponseDTO,
+  LoginRequestDTO,
+  SignupRequestDTO,
+} from './dto';
+import { JwtGuard } from './guard';
+import { SignupPipe } from './pipe';
+
+@ApiTags('auth')
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @DocumentHelper(API_DOC_TYPE.SIGNUP)
+  @Post('signup')
+  @HttpCode(201)
+  async signup(
+    @Body(SignupPipe) newUser: SignupRequestDTO,
+  ): Promise<AccessTokenResponseDTO> {
+    return this.authService.signup(newUser);
+  }
+
+  @DocumentHelper(API_DOC_TYPE.LOGIN)
+  @Post('login')
+  @HttpCode(201)
+  async login(@Body() login: LoginRequestDTO): Promise<AccessTokenResponseDTO> {
+    return this.authService.login(login);
+  }
+
+  @ApiAuthDocument()
+  @DocumentHelper(API_DOC_TYPE.ME)
+  @UseGuards(JwtGuard)
+  @Get('me')
+  @HttpCode(204)
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  me(): void {}
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+
+@Module({
+  imports: [JwtModule.register({ secret: '$up3r$3cr3t' })],
+  controllers: [AuthController],
+  providers: [AuthService],
+  exports: [JwtModule],
+})
+export class AuthModule {}

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AuthService],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,0 +1,70 @@
+import {
+  ConflictException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import * as argon2 from 'argon2';
+import {
+  AccessTokenResponseDTO,
+  LoginRequestDTO,
+  SignupRequestDTO,
+} from './dto';
+import { JwtPayload, User } from './interface';
+
+@Injectable()
+export class AuthService {
+  private users: User[] = [];
+
+  constructor(private readonly jwtService: JwtService) {}
+
+  findUser(username: string): User | undefined {
+    return this.users.find((u) => u.username === username);
+  }
+
+  async signup(newUser: SignupRequestDTO): Promise<AccessTokenResponseDTO> {
+    const foundUser = this.findUser(newUser.username);
+    if (foundUser) {
+      throw new ConflictException(
+        `User with username ${newUser.username} already exists`,
+      );
+    }
+    const user = await this.createUser(newUser);
+    return this.createAccessToken(user.username);
+  }
+
+  async login(login: LoginRequestDTO): Promise<AccessTokenResponseDTO> {
+    try {
+      const foundUser = this.findUser(login.username);
+      if (!foundUser) {
+        throw new Error();
+      }
+      const passwordMatch = await argon2.verify(
+        foundUser.password,
+        login.password,
+      );
+      if (!passwordMatch) {
+        throw new Error();
+      }
+      return this.createAccessToken(login.username);
+    } catch (error) {
+      throw new UnauthorizedException(
+        'Username or password may be incorrect. Please try again',
+      );
+    }
+  }
+
+  private createAccessToken(username: string): AccessTokenResponseDTO {
+    const jwtPayload: JwtPayload = { sub: username };
+    return { accessToken: this.jwtService.sign(jwtPayload) };
+  }
+
+  private async createUser(newUser: SignupRequestDTO): Promise<User> {
+    const user = {
+      ...newUser,
+      password: await argon2.hash(newUser.password),
+    };
+    this.users.push(user);
+    return user;
+  }
+}

--- a/src/auth/constant/document.constant.ts
+++ b/src/auth/constant/document.constant.ts
@@ -1,0 +1,7 @@
+export const API_DOC_TYPE = {
+  SIGNUP: 'signup',
+  LOGIN: 'login',
+  ME: 'me',
+} as const;
+
+export type API_DOC_TYPE = typeof API_DOC_TYPE[keyof typeof API_DOC_TYPE];

--- a/src/auth/constant/index.ts
+++ b/src/auth/constant/index.ts
@@ -1,0 +1,1 @@
+export * from './document.constant';

--- a/src/auth/decorator/document.decorator.ts
+++ b/src/auth/decorator/document.decorator.ts
@@ -1,0 +1,57 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiNoContentResponse,
+  ApiOperation,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { API_DOC_TYPE } from '../constant';
+import { AccessTokenResponseDTO } from '../dto';
+
+export const DocumentHelper = (docType: API_DOC_TYPE) => {
+  return decorators[docType]();
+};
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+const decorators: Record<API_DOC_TYPE, Function> = {
+  signup: () =>
+    applyDecorators(
+      ApiOperation({ summary: 'Auth API - Signup' }),
+      ApiBadRequestResponse({
+        description: 'Invalid Request Body',
+      }),
+      ApiConflictResponse({
+        description: 'User with username ${username} already exists',
+      }),
+      ApiCreatedResponse({
+        description: 'Success Signup',
+        type: AccessTokenResponseDTO,
+      }),
+    ),
+  login: () =>
+    applyDecorators(
+      ApiOperation({ summary: 'Auth API - Login' }),
+      ApiBadRequestResponse({
+        description: 'Invalid Request Body',
+      }),
+      ApiUnauthorizedResponse({
+        description: 'Username or password may be incorrect. Please try again',
+      }),
+      ApiCreatedResponse({
+        description: 'Success login',
+        type: AccessTokenResponseDTO,
+      }),
+    ),
+  me: () =>
+    applyDecorators(
+      ApiOperation({ summary: 'Auth API - Me' }),
+      ApiUnauthorizedResponse({
+        description: 'Invalid Access Token',
+      }),
+      ApiNoContentResponse({
+        description: 'Success me',
+      }),
+    ),
+};

--- a/src/auth/decorator/index.ts
+++ b/src/auth/decorator/index.ts
@@ -1,0 +1,1 @@
+export * from './document.decorator';

--- a/src/auth/dto/index.ts
+++ b/src/auth/dto/index.ts
@@ -1,0 +1,2 @@
+export * from './request';
+export * from './response';

--- a/src/auth/dto/request/index.ts
+++ b/src/auth/dto/request/index.ts
@@ -1,0 +1,2 @@
+export * from './signup-request.dto';
+export * from './login-request.dto';

--- a/src/auth/dto/request/login-request.dto.ts
+++ b/src/auth/dto/request/login-request.dto.ts
@@ -1,0 +1,7 @@
+import { PickType } from '@nestjs/swagger';
+import { SignupRequestDTO } from './signup-request.dto';
+
+export class LoginRequestDTO extends PickType(SignupRequestDTO, [
+  'username',
+  'password',
+]) {}

--- a/src/auth/dto/request/signup-request.dto.ts
+++ b/src/auth/dto/request/signup-request.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SignupRequestDTO {
+  @ApiProperty({
+    description: 'User ID',
+  })
+  username: string;
+
+  @ApiProperty({
+    description: 'User Password',
+    minimum: 12,
+  })
+  password: string;
+
+  @ApiProperty({
+    description: 'User Confirmation Password',
+    minLength: 12,
+  })
+  confirmationPassword: string;
+
+  @ApiProperty({
+    description: 'User First Name',
+  })
+  firstName: string;
+
+  @ApiProperty({
+    description: 'User Last Name',
+  })
+  lastName: string;
+}

--- a/src/auth/dto/response/access-token-response.dto.ts
+++ b/src/auth/dto/response/access-token-response.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AccessTokenResponseDTO {
+  @ApiProperty({
+    description: 'Access Token',
+  })
+  accessToken: string;
+}

--- a/src/auth/dto/response/index.ts
+++ b/src/auth/dto/response/index.ts
@@ -1,0 +1,1 @@
+export * from './access-token-response.dto';

--- a/src/auth/dto/response/user.response.dto.ts
+++ b/src/auth/dto/response/user.response.dto.ts
@@ -1,0 +1,4 @@
+import { OmitType } from '@nestjs/swagger';
+import { SignupRequestDTO } from '../request';
+
+export class UserRequestDTO extends OmitType(SignupRequestDTO, ['password']) {}

--- a/src/auth/guard/index.ts
+++ b/src/auth/guard/index.ts
@@ -1,0 +1,1 @@
+export * from './jwt.guard';

--- a/src/auth/guard/jwt.guard.ts
+++ b/src/auth/guard/jwt.guard.ts
@@ -1,0 +1,44 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import {
+  CustomRequest,
+  JwtPayload,
+} from '../interface/custom-request.interface';
+
+@Injectable()
+export class JwtGuard implements CanActivate {
+  constructor(private readonly jwtService: JwtService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = this.getRequest<CustomRequest>(context);
+    try {
+      const token = this.getToken(request);
+      const user: JwtPayload = this.jwtService.verify(token);
+      request.user = user;
+      return true;
+    } catch (error) {
+      throw new UnauthorizedException();
+    }
+  }
+
+  protected getRequest<T>(context: ExecutionContext): T {
+    return context.switchToHttp().getRequest();
+  }
+
+  protected getToken(request: CustomRequest): string {
+    const authorization = request.headers['authorization'];
+    if (!authorization || Array.isArray(authorization)) {
+      throw new Error('Invalid Authorization Header');
+    }
+    if (!authorization.startsWith('Bearer')) {
+      throw new Error('Invalid Authorization Header');
+    }
+    const [, token] = authorization.split(' ');
+    return token;
+  }
+}

--- a/src/auth/interface/custom-request.interface.ts
+++ b/src/auth/interface/custom-request.interface.ts
@@ -1,0 +1,8 @@
+import { Request } from 'express';
+
+export type JwtPayload = { sub: string };
+
+export interface CustomRequest extends Request {
+  headers: Record<string, string | string[]>;
+  user?: JwtPayload;
+}

--- a/src/auth/interface/index.ts
+++ b/src/auth/interface/index.ts
@@ -1,0 +1,2 @@
+export * from './user.interface';
+export * from './custom-request.interface';

--- a/src/auth/interface/user.interface.ts
+++ b/src/auth/interface/user.interface.ts
@@ -1,0 +1,6 @@
+export interface User {
+  username: string;
+  password: string;
+  firstName: string;
+  lastName: string;
+}

--- a/src/auth/pipe/index.ts
+++ b/src/auth/pipe/index.ts
@@ -1,0 +1,1 @@
+export * from './signup.pipe';

--- a/src/auth/pipe/signup.pipe.ts
+++ b/src/auth/pipe/signup.pipe.ts
@@ -1,0 +1,39 @@
+import {
+  ArgumentMetadata,
+  BadRequestException,
+  PipeTransform,
+} from '@nestjs/common';
+import { SignupRequestDTO } from '../dto';
+
+export class SignupPipe implements PipeTransform {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public transform(value: unknown, _metadata: ArgumentMetadata) {
+    const errors: string[] = [];
+    if (!this.valueHasPassAndConfPass(value)) {
+      throw new BadRequestException('Invalid Request Body');
+    }
+    if (value.password.length < 12) {
+      errors.push('password should be at least 12 characters long');
+    }
+    if (value.password !== value.confirmationPassword) {
+      errors.push('password and confirmationPassword do not match');
+    }
+    if (errors.length) {
+      throw new BadRequestException(errors.join('\n'));
+    }
+    return value;
+  }
+
+  /**
+   * custom type guard
+   * @param val
+   * @returns boolean
+   */
+  private valueHasPassAndConfPass(val: unknown): val is SignupRequestDTO {
+    return (
+      typeof val === 'object' &&
+      'password' in val &&
+      'confirmationPassword' in val
+    );
+  }
+}

--- a/src/common/constant/auth.constant.ts
+++ b/src/common/constant/auth.constant.ts
@@ -1,0 +1,1 @@
+export const ACCESS_TOKEN_TAG = 'Access-Token';

--- a/src/common/constant/indext.ts
+++ b/src/common/constant/indext.ts
@@ -1,0 +1,1 @@
+export * from './auth.constant';

--- a/src/common/decorator/auth.document.decorator.ts
+++ b/src/common/decorator/auth.document.decorator.ts
@@ -1,0 +1,13 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBearerAuth, ApiUnauthorizedResponse } from '@nestjs/swagger';
+import { ACCESS_TOKEN_TAG } from '../constant/auth.constant';
+
+export function ApiAuthDocument() {
+  return applyDecorators(
+    ApiBearerAuth(ACCESS_TOKEN_TAG),
+    ApiUnauthorizedResponse({
+      description:
+        '[Authentication Error] Invalid credentials. (ex) token is expired',
+    }),
+  );
+}

--- a/src/common/decorator/index.ts
+++ b/src/common/decorator/index.ts
@@ -1,0 +1,1 @@
+export * from './auth.document.decorator';

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,0 +1,1 @@
+export * from './decorator';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,29 @@
 import { NestFactory } from '@nestjs/core';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
+import { ACCESS_TOKEN_TAG } from './common/constant/auth.constant';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  const swaggerConfig = new DocumentBuilder()
+    .setTitle('Auth Test API')
+    .setVersion('1.0.0')
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        name: 'Access JWT',
+        description: 'Enter Access Token',
+        in: 'header',
+      },
+      ACCESS_TOKEN_TAG,
+    )
+    .build();
+  const document = SwaggerModule.createDocument(app, swaggerConfig);
+  SwaggerModule.setup('/docs', app, document);
+
   await app.listen(3000);
 }
 bootstrap();


### PR DESCRIPTION
* feat: AuthModule 생성

AuthModule에 JwtModule 의존성 추가

* chore: @nestjs/swagger 신규 추가

* feat: main.ts에 swagger 세팅

* feat: Auth API - Signup 구현

## API 로직 구현
- AuthController
- AuthService

## Document 관련 로직 구현
- DocumentHelper
- API_DOC_TYPE

* feat: Auth API - Login 구현

## API 로직 구현
- AuthController
- AuthService

## Document 관련 로직 구현
- DocumentHelper
- API_DOC_TYPE

* feat: Sinup API Contorller @Body에 SignupPipe 적용

SignupPipe 신규 정의
1. DTO 타입 가드로 타입 체크
2. password 길이 체크
3. password와 confirmationPassword 일치 여부 확인

* feat: JwtGuard 신규 생성

- canActivate(): Guard 호출시 실행되는 메서드
- getRequest(): Http 요청을 반환하는 메서드
- getToken(): 요청 헤더에서 JWT를 꺼내는 메서드

* feat: Auth API - me 구현

## API 로직 구현
- AuthController
- AuthService

## Document 관련 로직 구현
- DocumentHelper
- API_DOC_TYPE

## main.ts Document 관련 로직 구현
- addBearerAuth()